### PR TITLE
jp - Copy existing CRUD API RecommendationRequest from team02

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsController.java
@@ -1,0 +1,166 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.method.P;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a REST controller for req requests
+ */
+
+ @Tag(name = "RecommendationRequests")
+ @RequestMapping("/api/recommendationrequests")
+ @RestController
+ @Slf4j
+
+public class RecommendationRequestsController extends ApiController {
+    @Autowired
+    RecommendationRequestRepository recommendationRequestRepository;
+
+    /**
+     * List all recommendation requests
+     * 
+     * @return an iterable of rec req
+     */
+    @Operation(summary= "List all recommendation reqs")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<RecommendationRequest> allRecommendationRequests() {
+        Iterable<RecommendationRequest> recommendationRequests = recommendationRequestRepository.findAll();
+        return recommendationRequests;
+    }
+
+    /**
+     * Get a single request by id
+     * 
+     * @param id the id of the rec req
+     * @return a recommendation request
+     */
+    @Operation(summary= "Get a single recommendation request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public RecommendationRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        return recommendationRequest;
+    }
+
+    /**
+     * Create a new rec req
+     * 
+     * @param requesterEmail the email of the requester
+     * @param professorEmail the professor to request
+     * @param explanation the explanation
+     * @param dateRequested the date requested
+     * @param dateNeeded the date it is needed
+     * @param done is it done
+     * @return the saved recommendation req
+     */
+    @Operation(summary= "Create a new rec req")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public RecommendationRequest postRecommendationRequest(
+            @Parameter(name="requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name="professorEmail") @RequestParam String professorEmail,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="dateRequested", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateRequested") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateRequested,
+            @Parameter(name="dateNeeded", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateNeeded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateNeeded,
+            @Parameter(name="done") @RequestParam boolean done)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("dateRequested={}", dateRequested);
+        log.info("dateNeeded={}", dateNeeded);
+
+        RecommendationRequest recommendationRequest = new RecommendationRequest();
+        recommendationRequest.setRequesterEmail(requesterEmail);
+        recommendationRequest.setProfessorEmail(professorEmail);
+        recommendationRequest.setExplanation(explanation);
+        recommendationRequest.setDateNeeded(dateNeeded);
+        recommendationRequest.setDateRequested(dateRequested);
+        recommendationRequest.setDone(done);
+
+        RecommendationRequest savedRecommendationRequest = recommendationRequestRepository.save(recommendationRequest);
+
+        return savedRecommendationRequest;
+    }
+    
+    /**
+     * Update a single rec req
+     * 
+     * @param id the id of the rec request to update
+     * @param incoming an object to copy from
+     * @return the saved recommendation req
+
+     */
+    @Operation(summary= "Update a single Recommendation Request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public RecommendationRequest updateRecommendationRequest(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid RecommendationRequest incoming) {
+
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+                recommendationRequest.setRequesterEmail(incoming.getRequesterEmail());
+                recommendationRequest.setProfessorEmail(incoming.getProfessorEmail());
+                recommendationRequest.setExplanation(incoming.getExplanation());
+                recommendationRequest.setDateNeeded(incoming.getDateNeeded());
+                recommendationRequest.setDateRequested(incoming.getDateRequested());
+                recommendationRequest.setDone(incoming.getDone());
+        
+                recommendationRequestRepository.save(recommendationRequest);
+        
+                return recommendationRequest;
+            }
+
+    /**
+     * Delete a Recommendation Request
+     * 
+     * @param id the id of the rec request to delete
+     * @return a message indicating the req request was deleted
+     */
+    @Operation(summary= "Delete a Recommendation Request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteRecommendationRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest recRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        recommendationRequestRepository.delete(recRequest);
+        return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "recommendationrequests")
+public class RecommendationRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String professorEmail;
+  private String explanation;
+  private LocalDateTime dateRequested;
+  private LocalDateTime dateNeeded;
+  private boolean done;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecommendationRequestRepository extends CrudRepository<RecommendationRequest, Long> {
+}

--- a/src/main/resources/db/migration/changes/RecommendationRequests.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequests.json
@@ -1,0 +1,81 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "RecommendationRequests",
+          "author": "MattP",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "RECOMMENDATIONREQUESTS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "RECOMMENDATIONREQUESTS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "PROFESSOR_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                      "column": {
+                        "name": "EXPLANATION",
+                        "type": "VARCHAR(255)"
+                      }
+                    },
+                  {
+                    "column": {
+                      "name": "DATE_REQUESTED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_NEEDED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DONE",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "RECOMMENDATIONREQUESTS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+  

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
@@ -1,0 +1,353 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = RecommendationRequestsController.class)
+@Import(TestConfig.class)
+
+public class RecommendationRequestsControllerTests extends ControllerTestCase {
+
+    @MockBean
+        RecommendationRequestRepository recommendationRequestRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/recommendationrequests/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/recommendationrequests/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/recommendationrequests/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/recommendationrequests?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // Authorization tests for /api/recommendationrequests/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/recommendationrequests/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/recommendationrequests/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+    
+    // // Tests with mocks for database actions
+        
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+            // arrange
+            LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            RecommendationRequest recommendationRequest = RecommendationRequest.builder()
+                            .requesterEmail("student@ucsb.edu")
+                            .professorEmail("prof@ucsb.edu")
+                            .explanation("test")
+                            .dateRequested(ldt)
+                            .dateNeeded(ldt)
+                            .done(false)
+                            .build();
+
+            when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.of(recommendationRequest));
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/recommendationrequests?id=7"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+            String expectedJson = mapper.writeValueAsString(recommendationRequest);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+            
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+            // arrange
+
+            when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/recommendationrequests?id=7"))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+
+            verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
+    }
+        
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_recommendationrequests() throws Exception {
+
+            // arrange
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                            .requesterEmail("student1@ucsb.edu")
+                            .professorEmail("prof1@ucsb.edu")
+                            .explanation("test1")
+                            .dateRequested(ldt1)
+                            .dateNeeded(ldt1)
+                            .done(false)
+                            .build();
+
+            LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+            RecommendationRequest recommendationRequest2 = RecommendationRequest.builder()
+                            .requesterEmail("student2@ucsb.edu")
+                            .professorEmail("prof2@ucsb.edu")
+                            .explanation("test2")
+                            .dateRequested(ldt2)
+                            .dateNeeded(ldt2)
+                            .done(false)
+                            .build();
+
+            ArrayList<RecommendationRequest> expectedRecommendationRequests = new ArrayList<>();
+            expectedRecommendationRequests.addAll(Arrays.asList(recommendationRequest1, recommendationRequest2));
+
+            when(recommendationRequestRepository.findAll()).thenReturn(expectedRecommendationRequests);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/recommendationrequests/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(recommendationRequestRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedRecommendationRequests);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_recommendationrequest() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                            .requesterEmail("student1@ucsb.edu")
+                            .professorEmail("prof1@ucsb.edu")
+                            .explanation("test1")
+                            .dateRequested(ldt1)
+                            .dateNeeded(ldt1)
+                            .done(true)
+                            .build();
+
+            when(recommendationRequestRepository.save(eq(recommendationRequest1))).thenReturn(recommendationRequest1);
+
+            // act
+           MvcResult response = mockMvc.perform(
+                            post("/api/recommendationrequests/post?requesterEmail=student1@ucsb.edu&professorEmail=prof1@ucsb.edu&explanation=test1&dateRequested=2022-01-03T00:00:00&dateNeeded=2022-01-03T00:00:00&done=true")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(recommendationRequestRepository, times(1)).save(recommendationRequest1);
+            String expectedJson = mapper.writeValueAsString(recommendationRequest1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+
+        // PUT TESTS
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_recommendationrequest() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+                RecommendationRequest recRequestOrig = RecommendationRequest.builder()
+                        .requesterEmail("student1@ucsb.edu")
+                        .professorEmail("prof1@ucsb.edu")
+                        .explanation("test1")
+                        .dateRequested(ldt1)
+                        .dateNeeded(ldt1)
+                        .done(false)
+                        .build();
+
+                RecommendationRequest recRequestEdited = RecommendationRequest.builder()
+                        .requesterEmail("student2@ucsb.edu")
+                        .professorEmail("prof2@ucsb.edu")
+                        .explanation("test2")
+                        .dateRequested(ldt2)
+                        .dateNeeded(ldt2)
+                        .done(true)
+                        .build();
+
+                String requestBody = mapper.writeValueAsString(recRequestEdited);
+
+                when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(recRequestOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/recommendationrequests?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).findById(67L);
+                verify(recommendationRequestRepository, times(1)).save(recRequestEdited); 
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_recommendationrequest_that_does_not_exist() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                RecommendationRequest recommendationRequestEdited = RecommendationRequest.builder()
+                        .requesterEmail("student2@ucsb.edu")
+                        .professorEmail("prof2@ucsb.edu")
+                        .explanation("test2")
+                        .dateRequested(ldt1)
+                        .dateNeeded(ldt1)
+                        .done(true)
+                        .build();
+
+                String requestBody = mapper.writeValueAsString(recommendationRequestEdited);
+
+                when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/recommendationrequests?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RecommendationRequest with id 67 not found", json.get("message"));
+
+        }
+
+
+        // DELETE TESTS
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_recommendationrequest() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                RecommendationRequest reqrequest1 = RecommendationRequest.builder()
+                        .requesterEmail("student1@ucsb.edu")
+                        .professorEmail("prof1@ucsb.edu")
+                        .explanation("test1")
+                        .dateRequested(ldt1)
+                        .dateNeeded(ldt1)
+                        .done(false)
+                        .build();
+
+                when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.of(reqrequest1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/recommendationrequests?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).findById(15L);
+                verify(recommendationRequestRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RecommendationRequest with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_recommendationrequest_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/recommendationrequests?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RecommendationRequest with id 15 not found", json.get("message"));
+        }
+
+}


### PR DESCRIPTION
In this PR, we copy over the RecommendationRequests entity/repository files as well as the RecommendationRequests controller and controller tests to update the code with the backend CRUD operations implemented in team01. Functionality and all tests pass according to team01 implementation standards.

In future PRs, we will work to implement the frontend to use these operations, but this is the first step towards the frontend changes.

Closes #26 
<img width="1458" alt="Screenshot 2024-10-29 at 5 52 05 PM" src="https://github.com/user-attachments/assets/42a0af23-efda-4244-b40f-96f4a5a775a4">
