### PR TITLE
Creating the Help Request Index Page

### DIFF
--- a/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
@@ -1,17 +1,47 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { hasRole, useCurrentUser } from "../../utils/currentUser";
+import { Button } from "react-bootstrap";
+import { useBackend } from "../../utils/useBackend";
+import React from "react";
+import HelpRequestTable from "../../components/HelpRequest/HelpRequestTable";
 
 export default function HelpRequestIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/helprequest/create"
+          style={{ float: "right" }}
+        >
+          Create Help Request
+        </Button>
+      );
+    }
+  };
+
+  const {
+    data: helpRequests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/helprequest/all"],
+    { method: "GET", url: "/api/helprequest/all" },
+    [],
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/helprequest/create">Create</a>
-        </p>
-        <p>
-          <a href="/helprequest/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Help Requests</h1>
+        <HelpRequestTable
+          helpRequests={helpRequests}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestIndexPage.stories.js
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestIndexPage.stories.js
@@ -1,0 +1,67 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+import HelpRequestIndexPage from "../../../main/pages/HelpRequest/HelpRequestIndexPage";
+import { helpRequestFixtures } from "../../../fixtures/helpRequestFixtures";
+
+export default {
+  title: "pages/helprequest/HelpRequestIndexPage",
+  component: HelpRequestIndexPage,
+};
+
+const Template = () => <HelpRequestIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/helprequest/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequest/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequest);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequest/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequest);
+    }),
+    http.delete("/api/helprequest", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -7,9 +7,23 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { helpRequestFixtures } from "../../../fixtures/helpRequestFixtures";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
 
 describe("HelpRequestIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "HelpRequestTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,14 +36,74 @@ describe("HelpRequestIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
 
-    setupUserOnly();
+  test("Renders with Create Button for admin user", async () => {
+    // arrange
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/helprequest/all").reply(200, []);
 
     // act
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
 
+    await screen.findByText(/Create Help Request/);
+    const button = screen.getByText(/Create Help Request/);
+    expect(button).toHaveAttribute("href", "/helprequest/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three dates correctly for regular user", async () => {
+    // arrange
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/helprequest/all")
+      .reply(200, helpRequestFixtures.threeHelpRequest);
+
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByTestId(`${testId}-cell-row-0-col-id`);
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    // assert that the Create button is not present when user isn't an admin
+    expect(screen.queryByText(/Create Help Request/)).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    // arrange
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/helprequest/all").timeout();
+    const restoreConsole = mockConsole();
+
+    // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,13 +112,60 @@ describe("HelpRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    // assert
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/helprequest/all",
+    );
+    restoreConsole();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    // arrange
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/helprequest/all")
+      .reply(200, helpRequestFixtures.threeHelpRequest);
+    axiosMock
+      .onDelete("/api/helprequest")
+      .reply(200, "Help Request with id 1 was deleted");
+
+    // act
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
 
     // assert
-    expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+
+    await screen.findByTestId(`${testId}-cell-row-0-col-id`);
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act
+    fireEvent.click(deleteButton);
+
+    // assert
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("Help Request with id 1 was deleted");
+    });
   });
 });


### PR DESCRIPTION
In this PR, I replace the placeholder values in the HelpRequestIndexPage with actual code. It requests all the help requests from the backend, and displays them with the HelpRequestTable component. 

Photo of page, as rendered on Storybook:
![image](https://github.com/user-attachments/assets/206096d7-e26a-4091-92f3-e4b80684befb)


link to storybook: https://67217d09054c99a597a2d9ac-mvwpkcvwjw.chromatic.com/?path=/story/pages-helprequest-helprequestindexpage--three-items-admin-user

Dokku URL: https://team02-daniel-dev.dokku-00.cs.ucsb.edu/helprequest

Closes #50, Close after #74