### PR TITLE
pc - add form for Commits

### DIFF
--- a/frontend/src/fixtures/commitFixtures.js
+++ b/frontend/src/fixtures/commitFixtures.js
@@ -1,0 +1,35 @@
+const commitFixtures = {
+    oneCommit:  {
+        "id": 1,
+        "message": "pc - updated tests for blah controller",
+        "url": "https://github.com/ucsb-cs156-f24/team02-f24-00/commit/fe7825cf06b420552141f587a9499273b6d09916",
+        "authorLogin": "pconrad",
+        "commitTime": "2024-10-31T12:34:00Z"
+      },
+    threeCommits: [
+        {
+          "id": 1,
+          "message": "pc - updated tests for blah controller",
+          "url": "https://github.com/ucsb-cs156-f24/team02-f24-00/commit/fe7825cf06b420552141f587a9499273b6d09916",
+          "authorLogin": "pconrad",
+          "commitTime": "2024-10-31T12:34:00Z"
+        },
+            {
+          "id": 3,
+          "message": "dj-added backend files for help request",
+          "url": "https://github.com/ucsb-cs156-f24/team02-f24-00/commit/51987a8c30e3f1014cc0c40438b48df66682448b",
+          "authorLogin": "Division7",
+          "commitTime": "2024-10-31T12:34:00Z"
+        },
+        {
+          "id": 4,
+          "message": "dj - forgot the linter existed. ran it now ",
+          "url": "https://github.com/ucsb-cs156-f24/team02-f24-00/pull/77/commits/25abe6abe91ce7a8b69afe56672f797a31e7b230",
+          "authorLogin": "Division7",
+          "commitTime": "2024-11-04T15:12:00Z"
+        }
+      ]
+  };
+  
+  export { commitFixtures };
+  

--- a/frontend/src/fixtures/commitFixtures.js
+++ b/frontend/src/fixtures/commitFixtures.js
@@ -1,35 +1,34 @@
 const commitFixtures = {
-    oneCommit:  {
-        "id": 1,
-        "message": "pc - updated tests for blah controller",
-        "url": "https://github.com/ucsb-cs156-f24/team02-f24-00/commit/fe7825cf06b420552141f587a9499273b6d09916",
-        "authorLogin": "pconrad",
-        "commitTime": "2024-10-31T12:34:00Z"
-      },
-    threeCommits: [
-        {
-          "id": 1,
-          "message": "pc - updated tests for blah controller",
-          "url": "https://github.com/ucsb-cs156-f24/team02-f24-00/commit/fe7825cf06b420552141f587a9499273b6d09916",
-          "authorLogin": "pconrad",
-          "commitTime": "2024-10-31T12:34:00Z"
-        },
-            {
-          "id": 3,
-          "message": "dj-added backend files for help request",
-          "url": "https://github.com/ucsb-cs156-f24/team02-f24-00/commit/51987a8c30e3f1014cc0c40438b48df66682448b",
-          "authorLogin": "Division7",
-          "commitTime": "2024-10-31T12:34:00Z"
-        },
-        {
-          "id": 4,
-          "message": "dj - forgot the linter existed. ran it now ",
-          "url": "https://github.com/ucsb-cs156-f24/team02-f24-00/pull/77/commits/25abe6abe91ce7a8b69afe56672f797a31e7b230",
-          "authorLogin": "Division7",
-          "commitTime": "2024-11-04T15:12:00Z"
-        }
-      ]
-  };
-  
-  export { commitFixtures };
-  
+  oneCommit: {
+    id: 1,
+    message: "pc - updated tests for blah controller",
+    url: "https://github.com/ucsb-cs156-f24/team02-f24-00/commit/fe7825cf06b420552141f587a9499273b6d09916",
+    authorLogin: "pconrad",
+    commitTime: "2024-10-31T12:34:00Z",
+  },
+  threeCommits: [
+    {
+      id: 1,
+      message: "pc - updated tests for blah controller",
+      url: "https://github.com/ucsb-cs156-f24/team02-f24-00/commit/fe7825cf06b420552141f587a9499273b6d09916",
+      authorLogin: "pconrad",
+      commitTime: "2024-10-31T12:34:00Z",
+    },
+    {
+      id: 3,
+      message: "dj-added backend files for help request",
+      url: "https://github.com/ucsb-cs156-f24/team02-f24-00/commit/51987a8c30e3f1014cc0c40438b48df66682448b",
+      authorLogin: "Division7",
+      commitTime: "2024-10-31T12:34:00Z",
+    },
+    {
+      id: 4,
+      message: "dj - forgot the linter existed. ran it now ",
+      url: "https://github.com/ucsb-cs156-f24/team02-f24-00/pull/77/commits/25abe6abe91ce7a8b69afe56672f797a31e7b230",
+      authorLogin: "Division7",
+      commitTime: "2024-11-04T15:12:00Z",
+    },
+  ],
+};
+
+export { commitFixtures };

--- a/frontend/src/main/components/Commits/CommitForm.js
+++ b/frontend/src/main/components/Commits/CommitForm.js
@@ -2,11 +2,15 @@ import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
+export function removeZ(myString) {
+  return myString.replace("Z", "");
+}
+
 function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
   const defaultValues = initialContents
     ? {
         ...initialContents,
-        commitTime: initialContents.commitTime.replace("Z", ""),
+        commitTime: removeZ(initialContents.commitTime)
       }
     : {};
 
@@ -69,7 +73,6 @@ function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
       <Form.Group className="mb-3">
         <Form.Label htmlFor="url">Url</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-url"}
           id="url"
           type="text"
           isInvalid={Boolean(errors.url)}
@@ -85,7 +88,6 @@ function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
       <Form.Group className="mb-3">
         <Form.Label htmlFor="authorLogin">Author Login</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-authorLogin"}
           id="authorLogin"
           type="text"
           isInvalid={Boolean(errors.authorLogin)}
@@ -101,7 +103,6 @@ function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
       <Form.Group className="mb-3">
         <Form.Label htmlFor="commitTime">Commit Time (in UTC)</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-commitTime"}
           id="commitTime"
           type="datetime-local"
           isInvalid={Boolean(errors.commitTime)}
@@ -115,9 +116,7 @@ function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
-        {buttonLabel}
-      </Button>
+      <Button type="submit">{buttonLabel}</Button>
       <Button
         variant="Secondary"
         onClick={() => navigate(-1)}

--- a/frontend/src/main/components/Commits/CommitForm.js
+++ b/frontend/src/main/components/Commits/CommitForm.js
@@ -8,7 +8,13 @@ function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm({ defaultValues: initialContents || {} });
+  } = useForm({
+    defaultValues:
+      {
+        ...initialContents,
+        commitTime: initialContents.commitTime.replace("Z", ""),
+      } || {},
+  });
   // Stryker restore all
 
   const navigate = useNavigate();
@@ -74,9 +80,6 @@ function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
           {errors.url?.message}
         </Form.Control.Feedback>
       </Form.Group>
-
-
-
 
       <Form.Group className="mb-3">
         <Form.Label htmlFor="authorLogin">Author Login</Form.Label>

--- a/frontend/src/main/components/Commits/CommitForm.js
+++ b/frontend/src/main/components/Commits/CommitForm.js
@@ -15,6 +15,14 @@ function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
 
   const testIdPrefix = "CommitForm";
 
+  // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+  // Note that even this complex regex may still need some tweaks
+
+  // Stryker disable Regex
+  const isodate_regex =
+    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+  // Stryker restore Regex
+
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       {initialContents && (
@@ -64,6 +72,42 @@ function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
         />
         <Form.Control.Feedback type="invalid">
           {errors.url?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+
+
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="authorLogin">Author Login</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-authorLogin"}
+          id="authorLogin"
+          type="text"
+          isInvalid={Boolean(errors.authorLogin)}
+          {...register("authorLogin", {
+            required: "Author Login is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.authorLogin?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="commitTime">Commit Time (in UTC)</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-commitTime"}
+          id="commitTime"
+          type="datetime-local"
+          isInvalid={Boolean(errors.commitTime)}
+          {...register("commitTime", {
+            required: true,
+            pattern: isodate_regex,
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.commitTime && "Commit Time is required. "}
         </Form.Control.Feedback>
       </Form.Group>
 

--- a/frontend/src/main/components/Commits/CommitForm.js
+++ b/frontend/src/main/components/Commits/CommitForm.js
@@ -2,7 +2,7 @@ import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
-function CommitForm( { initialContents, submitAction, buttonLabel = "Create" } ) {
+function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
   // Stryker disable all
   const {
     register,

--- a/frontend/src/main/components/Commits/CommitForm.js
+++ b/frontend/src/main/components/Commits/CommitForm.js
@@ -1,0 +1,84 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+function CommitForm( { initialContents, submitAction, buttonLabel = "Create" } ) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "CommitForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="message">Message</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-message"}
+          id="message"
+          type="text"
+          isInvalid={Boolean(errors.message)}
+          {...register("message", {
+            required: "Message is required.",
+            maxLength: {
+              value: 255,
+              message: "Max length 255 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.message?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="url">Url</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-url"}
+          id="url"
+          type="text"
+          isInvalid={Boolean(errors.url)}
+          {...register("url", {
+            required: "Url is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.url?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default CommitForm;

--- a/frontend/src/main/components/Commits/CommitForm.js
+++ b/frontend/src/main/components/Commits/CommitForm.js
@@ -3,18 +3,19 @@ import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
 function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+  const defaultValues = initialContents
+    ? {
+        ...initialContents,
+        commitTime: initialContents.commitTime.replace("Z", ""),
+      }
+    : {};
+
   // Stryker disable all
   const {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm({
-    defaultValues:
-      {
-        ...initialContents,
-        commitTime: initialContents.commitTime.replace("Z", ""),
-      } || {},
-  });
+  } = useForm({ defaultValues });
   // Stryker restore all
 
   const navigate = useNavigate();

--- a/frontend/src/main/components/Commits/CommitForm.js
+++ b/frontend/src/main/components/Commits/CommitForm.js
@@ -10,7 +10,7 @@ function CommitForm({ initialContents, submitAction, buttonLabel = "Create" }) {
   const defaultValues = initialContents
     ? {
         ...initialContents,
-        commitTime: removeZ(initialContents.commitTime)
+        commitTime: removeZ(initialContents.commitTime),
       }
     : {};
 

--- a/frontend/src/stories/components/Commits/CommitForm.stories.js
+++ b/frontend/src/stories/components/Commits/CommitForm.stories.js
@@ -1,0 +1,33 @@
+import React from "react";
+import CommitForm from "main/components/Commits/CommitForm";
+import { commitFixtures } from "fixtures/commitFixtures";
+
+export default {
+  title: "components/Commits/CommitForm",
+  component: CommitForm,
+};
+
+const Template = (args) => {
+  return <CommitForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: commitFixtures.oneCommit,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/Commits/CommitForm.test.js
+++ b/frontend/src/tests/components/Commits/CommitForm.test.js
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 
-import CommitForm, {removeZ} from "main/components/Commits/CommitForm";
+import CommitForm, { removeZ } from "main/components/Commits/CommitForm";
 import { commitFixtures } from "fixtures/commitFixtures";
 
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -14,7 +14,6 @@ jest.mock("react-router-dom", () => ({
 }));
 
 describe("CommitForm tests", () => {
-
   const queryClient = new QueryClient();
 
   const expectedHeaders = [
@@ -66,9 +65,15 @@ describe("CommitForm tests", () => {
     expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
     expect(screen.getByText(`Id`)).toBeInTheDocument();
 
-    expect(screen.getByLabelText("Id")).toHaveValue(String(commitFixtures.oneCommit.id));
-    expect(screen.getByLabelText("Url")).toHaveValue(commitFixtures.oneCommit.url);
-    expect(screen.getByLabelText("Message")).toHaveValue(commitFixtures.oneCommit.message);
+    expect(screen.getByLabelText("Id")).toHaveValue(
+      String(commitFixtures.oneCommit.id),
+    );
+    expect(screen.getByLabelText("Url")).toHaveValue(
+      commitFixtures.oneCommit.url,
+    );
+    expect(screen.getByLabelText("Message")).toHaveValue(
+      commitFixtures.oneCommit.message,
+    );
   });
 
   test("that navigate(-1) is called when Cancel is clicked", async () => {

--- a/frontend/src/tests/components/Commits/CommitForm.test.js
+++ b/frontend/src/tests/components/Commits/CommitForm.test.js
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import CommitForm from "main/components/Commits/CommitForm";
+import { commitFixtures } from "fixtures/commitFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("CommitForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Message",
+    "Url",
+    "Author Login",
+    "Commit Time (in UTC)",
+  ];
+  const testId = "CommitForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CommitForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CommitForm initialContents={commitFixtures.oneCommit} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CommitForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CommitForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Message is required/);
+    expect(screen.getByText(/Url is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Author Login is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Commit Time is required/)).toBeInTheDocument();
+
+    const messageInput = screen.getByTestId(`${testId}-message`);
+    fireEvent.change(messageInput, { target: { value: "a".repeat(256) } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/tests/components/Commits/CommitForm.test.js
+++ b/frontend/src/tests/components/Commits/CommitForm.test.js
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 
-import CommitForm from "main/components/Commits/CommitForm";
+import CommitForm, {removeZ} from "main/components/Commits/CommitForm";
 import { commitFixtures } from "fixtures/commitFixtures";
 
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -14,6 +14,7 @@ jest.mock("react-router-dom", () => ({
 }));
 
 describe("CommitForm tests", () => {
+
   const queryClient = new QueryClient();
 
   const expectedHeaders = [
@@ -23,6 +24,11 @@ describe("CommitForm tests", () => {
     "Commit Time (in UTC)",
   ];
   const testId = "CommitForm";
+
+  test("that the removeZ function works propertly", () => {
+    expect(removeZ("ABC")).toBe("ABC");
+    expect(removeZ("ABCZ")).toBe("ABC");
+  });
 
   test("renders correctly with no initialContents", async () => {
     render(
@@ -59,6 +65,10 @@ describe("CommitForm tests", () => {
 
     expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
     expect(screen.getByText(`Id`)).toBeInTheDocument();
+
+    expect(screen.getByLabelText("Id")).toHaveValue(String(commitFixtures.oneCommit.id));
+    expect(screen.getByLabelText("Url")).toHaveValue(commitFixtures.oneCommit.url);
+    expect(screen.getByLabelText("Message")).toHaveValue(commitFixtures.oneCommit.message);
   });
 
   test("that navigate(-1) is called when Cancel is clicked", async () => {

--- a/src/main/java/edu/ucsb/cs156/example/controllers/CommitsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/CommitsController.java
@@ -1,0 +1,156 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.Commit;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.CommitRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+/**
+ * This is a REST controller for Commits
+ */
+
+@Tag(name = "Commits")
+@RequestMapping("/api/commits")
+@RestController
+@Slf4j
+public class CommitsController extends ApiController {
+
+    @Autowired
+    CommitRepository commitRepository;
+
+    /**
+     * List all Commits
+     * 
+     * @return an iterable of Commits
+     */
+    @Operation(summary = "List all commits")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Commit> allCommits() {
+        Iterable<Commit> commits = commitRepository.findAll();
+        return commits;
+    }
+
+    /**
+     * Create a new commit
+     * 
+     * @param message     the commit message
+     * @param url         the commit url
+     * @param authorLogin the github login id of the user that authored the commit
+     * @param commitTime  the timestamp on the commit, with time zone information
+     * @return the saved commit
+     */
+    @Operation(summary = "Create a new commit")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Commit postCommit(
+            @Parameter(name = "message") @RequestParam String message,
+            @Parameter(name = "url") @RequestParam String url,
+            @Parameter(name = "authorLogin") @RequestParam String authorLogin,
+            @Parameter(name = "commitTime") @RequestParam("commitTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) ZonedDateTime commitTime)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("commitTime={}", commitTime);
+
+        Commit commit = new Commit();
+        commit.setMessage(message);
+        commit.setUrl(url);
+        commit.setAuthorLogin(authorLogin);
+        commit.setCommitTime(commitTime);
+
+        Commit savedCommit = commitRepository.save(commit);
+
+        return savedCommit;
+    }
+
+    /**
+     * Get a single commit by id
+     * 
+     * @param id the id of the commit
+     * @return a Commit
+     */
+    @Operation(summary = "Get a single commit")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Commit getById(
+            @Parameter(name = "id") @RequestParam Long id) {
+        Commit commit = commitRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Commit.class, id));
+
+        return commit;
+    }
+
+    /**
+     * Update a single commit
+     * 
+     * @param id       id of the commit to update
+     * @param incoming the new commit
+     * @return the updated commit object
+     */
+    @Operation(summary = "Update a single commit")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public Commit updateCommit(
+            @Parameter(name = "id") @RequestParam Long id,
+            @RequestBody @Valid Commit incoming) {
+
+        Commit commit = commitRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Commit.class, id));
+
+        commit.setAuthorLogin(incoming.getAuthorLogin());
+        commit.setCommitTime(incoming.getCommitTime());
+        commit.setMessage(incoming.getMessage());
+        commit.setUrl(incoming.getUrl());
+
+        commitRepository.save(commit);
+
+        return commit;
+    }
+
+    /**
+     * Delete a Commit
+     * 
+     * @param id the id of the commit to delete
+     * @return a message indicating the commit was deleted
+     */
+    @Operation(summary = "Delete a Commit")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBDate(
+            @Parameter(name = "id") @RequestParam Long id) {
+        Commit commit = commitRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Commit.class, id));
+
+        commitRepository.delete(commit);
+        return genericMessage("Commit with id %s deleted".formatted(id));
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/Commit.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Commit.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+/**
+ * This is a JPA entity that represents a Github Commit.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "commits")
+public class Commit {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String message;
+  private String url;
+  private String authorLogin;
+  ZonedDateTime commitTime;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/CommitRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/CommitRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Commit;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The CommitRepository is a repository for Commit entities.
+ */
+
+@Repository
+public interface CommitRepository extends CrudRepository<Commit, Long> {
+  
+}

--- a/src/main/resources/db/migration/changes/Commits.json
+++ b/src/main/resources/db/migration/changes/Commits.json
@@ -1,0 +1,68 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "Commits-1",
+          "author": "pconrad",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "COMMITS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "COMMITS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "MESSAGE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "AUTHOR_LOGIN",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMIT_TIME",
+                      "type": "TIMESTAMP WITH TIME ZONE"
+                    }
+                  }
+                ],
+                "tableName": "COMMITS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/CommitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/CommitsControllerTests.java
@@ -1,0 +1,329 @@
+package edu.ucsb.cs156.example.controllers;
+
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Commit;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.CommitRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+
+@WebMvcTest(controllers = CommitsController.class)
+@Import(TestConfig.class)
+public class CommitsControllerTests extends ControllerTestCase  {
+    
+    @MockBean
+    CommitRepository commitRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/commits/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/commits/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/commits/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/commits/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+            // arrange
+
+            ZonedDateTime zdt1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+            Commit commit1 = Commit.builder()
+                .url("https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630")
+                .message("Merge pull request #212 from ucsb-cs156-f24/pc-update-pom-xml\n" +  "pc - update version in pom.xml")
+                .authorLogin("pconrad")
+                .commitTime(zdt1)
+                .build();
+
+            ArrayList<Commit> expectedCommits = new ArrayList<>();
+            expectedCommits.add(commit1);
+
+            when(commitRepository.findAll()).thenReturn(expectedCommits);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/commits/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(commitRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedCommits);
+
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_committ() throws Exception {
+            // arrange
+
+            ZonedDateTime zdt1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+            Commit commit1 = Commit.builder()
+            .url("https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630")
+            .message("pc-updated")
+            .authorLogin("pconrad")
+            .commitTime(zdt1)
+            .build();
+         
+
+            when(commitRepository.save(eq(commit1))).thenReturn(commit1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/commits/post?message=pc-updated&url=https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630&authorLogin=pconrad&commitTime=2022-01-03T00:00:00Z")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(commitRepository, times(1)).save(eq(commit1));
+            String expectedJson = mapper.writeValueAsString(commit1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(get("/api/commits?id=7"))
+                            .andExpect(status().is(403)); // logged out users can't get by id
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_exist() throws Exception {
+
+            // arrange
+
+            ZonedDateTime zdt1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+            Commit commit1 = Commit.builder()
+            .url("https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630")
+            .message("pc-updated")
+            .authorLogin("pconrad")
+            .commitTime(zdt1)
+            .build();
+
+            when(commitRepository.findById(eq(7L))).thenReturn(Optional.of(commit1));
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/commits?id=7"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(commitRepository, times(1)).findById(eq(7L));
+            String expectedJson = mapper.writeValueAsString(commit1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+            // arrange
+
+            when(commitRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/commits?id=7"))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+
+            verify(commitRepository, times(1)).findById(eq(7L));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("Commit with id 7 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_an_existing_commit() throws Exception {
+            // arrange
+
+            ZonedDateTime zdt1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+            ZonedDateTime zdt2 = ZonedDateTime.parse("2022-01-04T00:00:00Z");
+
+
+            Commit commit1 = Commit.builder()
+            .url("https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630")
+            .message("pc-updated")
+            .authorLogin("pconrad")
+            .commitTime(zdt1)
+            .build();
+
+
+            Commit editedCommit = Commit.builder()
+            .url("https://github.com/ucsb-cs156-f24/STARTER-team01/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630")
+            .message("pc-new-message")
+            .authorLogin("cgaucho")
+            .commitTime(zdt2)
+            .build();
+           
+
+            String requestBody = mapper.writeValueAsString(editedCommit);
+
+            when(commitRepository.findById(eq(67L))).thenReturn(Optional.of(commit1));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/commits?id=67")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(commitRepository, times(1)).findById(67L);
+            verify(commitRepository, times(1)).save(editedCommit); 
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(requestBody, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_commit_that_does_not_exist() throws Exception {
+            // arrange
+
+            ZonedDateTime zdt1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+            Commit commit1 = Commit.builder()
+            .url("https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630")
+            .message("pc-updated")
+            .authorLogin("pconrad")
+            .commitTime(zdt1)
+            .build();
+
+          
+            String requestBody = mapper.writeValueAsString(commit1);
+
+            when(commitRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/commits?id=67")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(commitRepository, times(1)).findById(67L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("Commit with id 67 not found", json.get("message"));
+
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_commit() throws Exception {
+            // arrange
+
+            ZonedDateTime zdt1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+            Commit commit1 = Commit.builder()
+            .url("https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630")
+            .message("pc-updated")
+            .authorLogin("pconrad")
+            .commitTime(zdt1)
+            .build();
+
+            when(commitRepository.findById(eq(15L))).thenReturn(Optional.of(commit1));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/commits?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(commitRepository, times(1)).findById(15L);
+            verify(commitRepository, times(1)).delete(eq(commit1));
+
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("Commit with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_commit_and_gets_right_error_message()
+                    throws Exception {
+            // arrange
+
+            when(commitRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/commits?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(commitRepository, times(1)).findById(15L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("Commit with id 15 not found", json.get("message"));
+    }
+
+
+}


### PR DESCRIPTION
Closes #92 

Merge AFTER PR #98 

In this PR, we add a form for the Commits table.  

This only adds the form to the storybook; it is not yet integrated into the app.

To access the storybook, use this link:

https://67217d09054c99a597a2d9ac-kocpzfhlcq.chromatic.com/?path=/docs/components-commits-commitform--docs

# Screenshots

## Create

<img width="990" alt="image" src="https://github.com/user-attachments/assets/93f0af2b-dec0-4265-b132-491e59d92db2">

## Update

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/fc3f5b4b-025e-430b-a24c-3acb1f6569de">
