### PR TITLE
Update 82-kanban-slack-update.yml

### DIFF
--- a/.github/workflows/82-kanban-slack-update.yml
+++ b/.github/workflows/82-kanban-slack-update.yml
@@ -2,8 +2,12 @@ name: Kanban Slack Update
 
 # Instructions to set up the workflow
 #  1. Copy the workflow file to your repository in the .github/workflows directory.
-#  2. Create a personal access token called PAT and add it in the organization secrets with the name PAT.
-#  3. Create a Slack bot user and add the OAuth access token in the organization secrets with the name SLACK_BOT_USER_OAUTH_ACCESS_TOKEN.
+#  2. Ensure that the organization is configured for fine-grained personal access tokens, e.g. 
+#     https://github.com/organizations/ucsb-cs156-f24/settings/personal-access-tokens-onboarding     
+#  3. Create a fine grained personal access token for the organization; under organizations, 
+#     it should have read-only permission on projects.
+#  4. Add the secret called PAT and add it in the organization secrets with the name PAT.
+#  5. Create a Slack bot user and add the OAuth access token in the organization secrets with the name SLACK_BOT_USER_OAUTH_ACCESS_TOKEN.
 #  4. Update the TEAM_TO_CHANNEL environment variable with the mapping of team names to Slack channel IDs.
 #  5. Update the ORG_NAME environment variable with your GitHub organization name.
 #  6. Update the END_DATE environment variable with the end date for the workflow to stop running the workflow forever.


### PR DESCRIPTION
In this PR, we update `82-kanban-slack-update.yml`, which is a github action that will post a summary of the Kanban board status for a repo to a team slack channel at periodic scheduled intervals, on on `workflow_dispatch`.